### PR TITLE
Fix incorrect minimum Perl version

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,5 @@
 {
-    "perl"        : "v6.0.0",
+    "perl"        : "6.c",
     "name"        : "Template::Protone",
     "version"     : "0.1.0",
     "description" : "Perl6 embedded templates",


### PR DESCRIPTION
Without this change, the module is currently uninstallable:

```
$ panda install Template::Protone
==> Fetching Template::Protone
Please remove leading 'v' from perl version in Template::Protone's meta info.
Template::Protone requires Perl version 6.0.0. Cannot continue.
  in method check-perl-version at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 125
  in method install at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 145
  in method resolve at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 233
  in sub MAIN at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 18
  in block <unit> at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 150

$ 
```
