### PR TITLE
EVAL now requires use MONKEY-SEE-NO-EVAL;

### DIFF
--- a/lib/Template/Protone.pm6
+++ b/lib/Template/Protone.pm6
@@ -1,5 +1,7 @@
 unit class Template::Protone;
 
+use MONKEY-SEE-NO-EVAL;
+
 has Str $.open  = '<%';
 has Str $.close = '%>';
 has Bool $.trim = True;


### PR DESCRIPTION
A week or so prior to Christmas release, `EVAL` was deemed too dangerous to make easily available and it was decided its use would require inclusion of `use MONKEY-SEE-NO-EVAL;`. Without this PR, the module does not work and fails tests:

```
==> Installing Template::Protone from a local directory '.'
==> Fetching Template::Protone
==> Building Template::Protone
==> Testing Template::Protone
===SORRY!=== Error while compiling /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6
EVAL is a very dangerous function!!! (use MONKEY-SEE-NO-EVAL to override,
but only if you're VERY sure your data contains no injection attacks)
at /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6:24
------> $sub = EVAL " sub (\$data?) \{ $code \}"⏏;
===SORRY!=== Error while compiling /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6
EVAL is a very dangerous function!!! (use MONKEY-SEE-NO-EVAL to override,
but only if you're VERY sure your data contains no injection attacks)
at /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6:24
------> $sub = EVAL " sub (\$data?) \{ $code \}"⏏;
t/00-use.t ..... 
Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 
===SORRY!=== Error while compiling /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6
EVAL is a very dangerous function!!! (use MONKEY-SEE-NO-EVAL to override,
but only if you're VERY sure your data contains no injection attacks)
at /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6:24
------> $sub = EVAL " sub (\$data?) \{ $code \}"⏏;
===SORRY!=== Error while compiling /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6
EVAL is a very dangerous function!!! (use MONKEY-SEE-NO-EVAL to override,
but only if you're VERY sure your data contains no injection attacks)
at /tmp/tmp.xkHdFl6bhb/.panda-work/1454163889_1/lib/Template/Protone.pm6:24
------> $sub = EVAL " sub (\$data?) \{ $code \}"⏏;
t/01-simple.t .. 
Dubious, test returned 1 (wstat 256, 0x100)
No subtests run 

Test Summary Report
-------------------
t/00-use.t   (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/01-simple.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=2, Tests=0,  3 wallclock secs ( 0.02 usr  0.00 sys +  2.54 cusr  0.29 csys =  2.85 CPU)
Result: FAIL
The spawned process exited unsuccessfully (exit code: 1)
  in sub run-and-gather-output at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/5AEF9DA5AE15E5AB5CB2ADB58A455E007FA7839E line 85
  in block  at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/FB10E7A100D50F6DB505EC4DC538BEAB5154DED3 line 22
  in sub indir at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/5AEF9DA5AE15E5AB5CB2ADB58A455E007FA7839E line 20
  in method test at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/FB10E7A100D50F6DB505EC4DC538BEAB5154DED3 line 5
  in method install at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 155
  in method resolve at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/sources/9036849E1656E91211D00AB4530B81D29A7D6E82 line 233
  in sub MAIN at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 18
  in block <unit> at /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/resources/76CD539C815A33F2891D2EF3D6D96B1081567AD1 line 150

$ 
```
